### PR TITLE
Add parent in expressions context

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vega",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "description": "The Vega visualization grammar.",
   "keywords": [
     "vega",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vega",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "The Vega visualization grammar.",
   "keywords": [
     "vega",

--- a/src/core/View.js
+++ b/src/core/View.js
@@ -393,6 +393,7 @@ prototype.toImageURL = function(type) {
   // render the scenegraph
   var ren = new Renderer(v._model.config.load)
     .initialize(null, v._width, v._height, v._padding)
+    .background(v._bgcolor)
     .render(v._model.scene());
 
   sg.canvas.Renderer.RETINA = retina; // restore retina settings

--- a/src/parse/expr.js
+++ b/src/parse/expr.js
@@ -1,7 +1,7 @@
 var dl = require('datalib'),
     template = dl.template,
     expr = require('vega-expression'),
-    args = ['datum', 'event', 'signals'];
+    args = ['datum', 'parent', 'event', 'signals'];
 
 var compile = expr.compiler(args, {
   idWhiteList: args,

--- a/src/parse/properties.js
+++ b/src/parse/properties.js
@@ -186,7 +186,7 @@ function rule(model, name, rules, exprs) {
       deps.signals.push.apply(deps.signals, exprFn.globals);
       deps.data.push.apply(deps.data, exprFn.dataSources);
 
-      code += "if (exprs[" + exprs.length + "](item.datum, null)) {" +
+      code += "if (exprs[" + exprs.length + "](item.datum, item.mark.group.datum, null)) {" +
           "\n    d += set(o, "+dl.str(name)+", " +ref.val+");";
       code += rules[i+1] ? "\n  } else " : "  }";
 

--- a/src/parse/properties.js
+++ b/src/parse/properties.js
@@ -614,6 +614,7 @@ properties.schema = {
         "interpolate": valueSchema(["linear", "step-before", "step-after",
           "basis", "basis-open", "cardinal", "cardinal-open", "monotone"]),
         "tension": {"$ref": "#/refs/numberValue"},
+        "orient": valueSchema(["horizontal", "vertical"]),
 
         // Image-mark properties
         "url": {"$ref": "#/refs/stringValue"},

--- a/src/parse/streams.js
+++ b/src/parse/streams.js
@@ -57,7 +57,7 @@ function parseStreams(view) {
     view.on(type, function(evt, item) {
       evt.preventDefault(); // stop text selection
       extendEvent(evt, item);
-      fire(internal, type, (item && item.datum) || {}, evt);
+      fire(internal, type, (item && item.datum) || {}, (item && item.mark && item.mark.group && item.mark.group.datum) || {}, evt);
     });
   });
 
@@ -72,7 +72,7 @@ function parseStreams(view) {
 
     function handler(evt) {
       extendEvent(evt);
-      fire(external, type, d3.select(this).datum(), evt);
+      fire(external, type, d3.select(this).datum(), this.parentNode && d3.select(this.parentNode).datum(), evt);
     }
 
     for (var i=0; i<elt.length; ++i) {
@@ -125,7 +125,7 @@ function parseStreams(view) {
     evt.vg.y = mouse[1] - pad.top;
   }
 
-  function fire(registry, type, datum, evt) {
+  function fire(registry, type, datum, parent, evt) {
     var handlers = registry.handlers[type],
         node = registry.nodes[type],
         cs = df.ChangeSet.create(null, true),
@@ -133,7 +133,7 @@ function parseStreams(view) {
         val, i, n, h;
 
     function invoke(f) {
-      return !f.fn(datum, evt);
+      return !f.fn(datum, parent, evt);
     }
 
     for (i=0, n=handlers.length; i<n; ++i) {
@@ -141,7 +141,7 @@ function parseStreams(view) {
       filtered = h.filters.some(invoke);
       if (filtered) continue;
 
-      val = h.exp.fn(datum, evt);
+      val = h.exp.fn(datum, parent, evt);
       if (h.spec.scale) {
         val = parseSignals.scale(model, h.spec, val, datum, evt);
       }

--- a/src/parse/streams.js
+++ b/src/parse/streams.js
@@ -155,7 +155,12 @@ function parseStreams(view) {
       if (s.event)       domEvent(sig, s, exp, spec);
       else if (s.signal) signal(sig, s, exp, spec);
       else if (s.start)  orderedStream(sig, s, exp, spec);
-      else if (s.stream) mergedStream(sig, s.stream, exp, spec);
+      else if (s.stream) {
+        if (s.filters) s.stream.forEach(function(ms) {
+          ms.filters = dl.array(ms.filters).concat(s.filters);
+        });
+        mergedStream(sig, s.stream, exp, spec);
+      }
     });
   }
 

--- a/src/parse/streams.js
+++ b/src/parse/streams.js
@@ -9,7 +9,12 @@ var GATEKEEPER = '_vgGATEKEEPER',
 
 var vgEvent = {
   getItem: function() { return this.item; },
-  getGroup: function(name) { return name ? this.name[name] : this.group; },
+  getGroup: function(name) {
+    var group = name ? this.name[name] : this.group,
+        mark = group && group.mark,
+        interactive = mark && (mark.interactive || mark.interactive === undefined);
+    return interactive ? group : {};
+  },
   getXY: function(item) {
       var p = {x: this.x, y: this.y};
       if (typeof item === 'string') {

--- a/src/transforms/Formula.js
+++ b/src/transforms/Formula.js
@@ -20,10 +20,12 @@ prototype.transform = function(input) {
   log.debug(input, ['formulating']);
 
   var field = this.param('field'),
-      expr = this.param('expr');
+      expr = this.param('expr'),
+      updated = false;
 
   function set(x) {
     Tuple.set(x, field, expr(x));
+    updated = true;
   }
 
   input.add.forEach(set);
@@ -32,7 +34,7 @@ prototype.transform = function(input) {
     input.mod.forEach(set);
   }
 
-  input.fields[field] = 1;
+  if (updated) input.fields[field] = 1;
   return input;
 };
 

--- a/src/transforms/Voronoi.js
+++ b/src/transforms/Voronoi.js
@@ -36,7 +36,7 @@ prototype.batchTransform = function(input, data) {
 
   // build and assign path strings
   for (var i=0; i<data.length; ++i) {
-    Tuple.set(data[i], pathname, 'M' + polygons[i].join('L') + 'Z');
+    if (polygons[i]) Tuple.set(data[i], pathname, 'M' + polygons[i].join('L') + 'Z');
   }
 
   // return changeset

--- a/test/spec/scene.json
+++ b/test/spec/scene.json
@@ -1,0 +1,63 @@
+{
+  "width": 400,
+  "height": 200,
+  "padding": {"top": 10, "left": 30, "bottom": 30, "right": 10},
+  "background": "red",
+  "scene": {
+    "fill": "white",
+    "fillOpacity": 0.5,
+    "stroke": "black",
+    "strokeWidth": 2,
+    "strokeOpacity": 0.5
+  },
+  "data": [
+    {
+      "name": "table",
+      "values": [
+        {"x": 1,  "y": 28}, {"x": 2,  "y": 55},
+        {"x": 3,  "y": 43}, {"x": 4,  "y": 91},
+        {"x": 5,  "y": 81}, {"x": 6,  "y": 53},
+        {"x": 7,  "y": 19}, {"x": 8,  "y": 87}
+      ]
+    }
+  ],
+  "scales": [
+    {
+      "name": "x",
+      "type": "ordinal",
+      "range": "width",
+      "domain": {"data": "table", "field": "x"}
+    },
+    {
+      "name": "y",
+      "type": "linear",
+      "range": "height",
+      "domain": {"data": "table", "field": "y"},
+      "nice": true
+    }
+  ],
+  "axes": [
+    {"type": "x", "scale": "x"},
+    {"type": "y", "scale": "y"}
+  ],
+  "marks": [
+    {
+      "type": "rect",
+      "from": {"data": "table"},
+      "properties": {
+        "enter": {
+          "x": {"scale": "x", "field": "x"},
+          "width": {"scale": "x", "band": true, "offset": -1},
+          "y": {"scale": "y", "field": "y"},
+          "y2": {"scale": "y", "value": 0}
+        },
+        "update": {
+          "fill": {"value": "steelblue"}
+        },
+        "hover": {
+          "fill": {"value": "red"}
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
From an expression, it can be useful to access the current datum’s
parent. This commit allows to use `parent` the same way as `datum`
within any expression.

This pull request can be an example if you want to implement it differently, but I haven’t found any work around.

Fixes https://github.com/vega/vega/issues/560